### PR TITLE
Parse Facebook Browser for JS Polyfill

### DIFF
--- a/compute.go
+++ b/compute.go
@@ -26,6 +26,13 @@ func (c *Composer) parse(userAgent string) (browser types.Browser, v version.Ver
 	// TODO(can we stick to just pulling out major/minor/patch and avoid this slow parse?)
 	ua := c.uaParser.ParseUserAgent(userAgent)
 	switch ua.Family {
+	case "Facebook":
+		if c.uaParser.ParseOs(userAgent).Family == "iOS" {
+			browser = types.IOSSafari
+		}
+		if c.uaParser.ParseOs(userAgent).Family == "Android" {
+			browser = types.Chrome
+		}
 	case "Firefox":
 		browser = types.Firefox
 	case "Firefox Mobile":


### PR DESCRIPTION
Facebook user agent claims its own browser type even when it's just wrapping a webview.  This assumes we can default to the OS specific one since Facebook is just wrapping a Webview.